### PR TITLE
リリースCIにcheckoutのstep追加

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,6 +12,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3.0.2
       - uses: ./
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
https://github.com/dev-hato/actions-create-release/runs/7358854247?check_suite_focus=true

```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/actions-create-release/actions-create-release'. Did you forget to run actions/checkout before running your local action?
```

checkoutしないと `action.yml` を参照できないので、checkoutのstepを追加します。