### PR TITLE
create-release自身の差分がある場合もリリースする

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/create-release.yml
       - action.yml
 
 jobs:


### PR DESCRIPTION
`create-release` 自身の差分がある場合はCIの動作確認をしたいのでリリースするようにします。