### PR TITLE
リリース作成時にコミットを明示的に指定する

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,8 @@ runs:
           return version.join('.');
     - name: Create release
       uses: actions/github-script@v6.1.0
+      env:
+        GITHUB_REF: ${{env.GITHUB_REF}}
       with:
         github-token: ${{inputs.github-token}}
         script: |
@@ -65,6 +67,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             tag_name: '${{ steps.increment_version.outputs.result }}',
+            target_commitish: process.env['GITHUB_REF'],
             generate_release_notes: true
           };
           console.log("call repos.createRelease:", createReleaseParams);


### PR DESCRIPTION
現状では最新のmain (master) のコミットのリリースを作成するようになっていますが、リリースを作成するコミットを明示的に指定することで、意図通りリリースが作成されることを担保できるようにします。