### PR TITLE
CI内のスクリプトを別ファイルに分離する

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,64 +11,21 @@ runs:
     - name: Increment version
       id: increment_version
       uses: actions/github-script@v6.3.3
+      env:
+        SHA: ${{ github.sha }}
       with:
         github-token: ${{inputs.github-token}}
         result-encoding: string
         script: |
-          let latestReleaseVersion = '';
-
-          try {
-            const getLatestReleaseParams = {
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            };
-            console.log("call repos.getLatestRelease:", getLatestReleaseParams);
-            const latestRelease = await github.rest.repos.getLatestRelease(getLatestReleaseParams);
-            latestReleaseVersion = latestRelease.data.tag_name;
-          } catch (e) {
-            if (e.status === 404) {
-              latestReleaseVersion = 'v0.0.0';
-            } else {
-              throw e;
-            }
-          }
-
-          const listPullRequestsAssociatedWithCommitParams = {
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            commit_sha: '${{ github.sha }}',
-          };
-          console.log("call repos.listPullRequestsAssociatedWithCommit:", listPullRequestsAssociatedWithCommitParams);
-          const pulls = await github.paginate(
-            github.rest.repos.listPullRequestsAssociatedWithCommit,
-            listPullRequestsAssociatedWithCommitParams
-          );
-          const labels = pulls.flatMap(p => p.labels.map(l => l.name));
-          const tagNames = latestReleaseVersion.split('.');
-          let version = [];
-
-          if (labels.includes('major release')) {
-            version = [`v${Number(tagNames[0].replace('v', '')) + 1}`, 0, 0];
-          } else if (labels.includes('minor release')) {
-            version = [tagNames[0], Number(tagNames[1]) + 1, 0];
-          } else {
-            version = [tagNames[0], tagNames[1], Number(tagNames[2]) + 1];
-          }
-
-          return version.join('.');
+          const script = require('${{ github.action_path }}/scripts/action/increment_version.js')
+          return await script({github, context})
     - name: Create release
       uses: actions/github-script@v6.3.3
       env:
         GITHUB_REF: ${{env.GITHUB_REF}}
+        TAG_NAME: ${{ steps.increment_version.outputs.result }}
       with:
         github-token: ${{inputs.github-token}}
         script: |
-          const createReleaseParams = {
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            tag_name: '${{ steps.increment_version.outputs.result }}',
-            target_commitish: process.env['GITHUB_REF'],
-            generate_release_notes: true
-          };
-          console.log("call repos.createRelease:", createReleaseParams);
-          await github.rest.repos.createRelease(createReleaseParams);
+          const script = require('${{ github.action_path }}/scripts/action/create_release.js')
+          return await script({github, context})

--- a/scripts/action/create_release.js
+++ b/scripts/action/create_release.js
@@ -1,0 +1,11 @@
+module.exports = async ({github, context}) => {
+    const createReleaseParams = {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        tag_name: process.env.TAG_NAME,
+        target_commitish: process.env['GITHUB_REF'],
+        generate_release_notes: true
+    };
+    console.log("call repos.createRelease:", createReleaseParams);
+    await github.rest.repos.createRelease(createReleaseParams);
+}

--- a/scripts/action/create_release.js
+++ b/scripts/action/create_release.js
@@ -1,11 +1,11 @@
-module.exports = async ({github, context}) => {
-    const createReleaseParams = {
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        tag_name: process.env.TAG_NAME,
-        target_commitish: process.env['GITHUB_REF'],
-        generate_release_notes: true
-    };
-    console.log("call repos.createRelease:", createReleaseParams);
-    await github.rest.repos.createRelease(createReleaseParams);
+module.exports = async ({ github, context }) => {
+  const createReleaseParams = {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    tag_name: process.env.TAG_NAME,
+    target_commitish: process.env.GITHUB_REF,
+    generate_release_notes: true
+  }
+  console.log('call repos.createRelease:', createReleaseParams)
+  await github.rest.repos.createRelease(createReleaseParams)
 }

--- a/scripts/action/increment_version.js
+++ b/scripts/action/increment_version.js
@@ -1,43 +1,43 @@
-module.exports = async ({github, context}) => {
-    let latestReleaseVersion = '';
+module.exports = async ({ github, context }) => {
+  let latestReleaseVersion = ''
 
-    try {
-        const getLatestReleaseParams = {
-            owner: context.repo.owner,
-            repo: context.repo.repo
-        };
-        console.log("call repos.getLatestRelease:", getLatestReleaseParams);
-        const latestRelease = await github.rest.repos.getLatestRelease(getLatestReleaseParams);
-        latestReleaseVersion = latestRelease.data.tag_name;
-    } catch (e) {
-        if (e.status === 404) {
-            latestReleaseVersion = 'v0.0.0';
-        } else {
-            throw e;
-        }
+  try {
+    const getLatestReleaseParams = {
+      owner: context.repo.owner,
+      repo: context.repo.repo
     }
-
-    const listPullRequestsAssociatedWithCommitParams = {
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        commit_sha: process.env.SHA,
-    };
-    console.log("call repos.listPullRequestsAssociatedWithCommit:", listPullRequestsAssociatedWithCommitParams);
-    const pulls = await github.paginate(
-        github.rest.repos.listPullRequestsAssociatedWithCommit,
-        listPullRequestsAssociatedWithCommitParams
-    );
-    const labels = pulls.flatMap(p => p.labels.map(l => l.name));
-    const tagNames = latestReleaseVersion.split('.');
-    let version;
-
-    if (labels.includes('major release')) {
-        version = [`v${Number(tagNames[0].replace('v', '')) + 1}`, 0, 0];
-    } else if (labels.includes('minor release')) {
-        version = [tagNames[0], Number(tagNames[1]) + 1, 0];
+    console.log('call repos.getLatestRelease:', getLatestReleaseParams)
+    const latestRelease = await github.rest.repos.getLatestRelease(getLatestReleaseParams)
+    latestReleaseVersion = latestRelease.data.tag_name
+  } catch (e) {
+    if (e.status === 404) {
+      latestReleaseVersion = 'v0.0.0'
     } else {
-        version = [tagNames[0], tagNames[1], Number(tagNames[2]) + 1];
+      throw e
     }
+  }
 
-    return version.join('.');
+  const listPullRequestsAssociatedWithCommitParams = {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    commit_sha: process.env.SHA
+  }
+  console.log('call repos.listPullRequestsAssociatedWithCommit:', listPullRequestsAssociatedWithCommitParams)
+  const pulls = await github.paginate(
+    github.rest.repos.listPullRequestsAssociatedWithCommit,
+    listPullRequestsAssociatedWithCommitParams
+  )
+  const labels = pulls.flatMap(p => p.labels.map(l => l.name))
+  const tagNames = latestReleaseVersion.split('.')
+  let version
+
+  if (labels.includes('major release')) {
+    version = [`v${Number(tagNames[0].replace('v', '')) + 1}`, 0, 0]
+  } else if (labels.includes('minor release')) {
+    version = [tagNames[0], Number(tagNames[1]) + 1, 0]
+  } else {
+    version = [tagNames[0], tagNames[1], Number(tagNames[2]) + 1]
+  }
+
+  return version.join('.')
 }

--- a/scripts/action/increment_version.js
+++ b/scripts/action/increment_version.js
@@ -1,0 +1,43 @@
+module.exports = async ({github, context}) => {
+    let latestReleaseVersion = '';
+
+    try {
+        const getLatestReleaseParams = {
+            owner: context.repo.owner,
+            repo: context.repo.repo
+        };
+        console.log("call repos.getLatestRelease:", getLatestReleaseParams);
+        const latestRelease = await github.rest.repos.getLatestRelease(getLatestReleaseParams);
+        latestReleaseVersion = latestRelease.data.tag_name;
+    } catch (e) {
+        if (e.status === 404) {
+            latestReleaseVersion = 'v0.0.0';
+        } else {
+            throw e;
+        }
+    }
+
+    const listPullRequestsAssociatedWithCommitParams = {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        commit_sha: process.env.SHA,
+    };
+    console.log("call repos.listPullRequestsAssociatedWithCommit:", listPullRequestsAssociatedWithCommitParams);
+    const pulls = await github.paginate(
+        github.rest.repos.listPullRequestsAssociatedWithCommit,
+        listPullRequestsAssociatedWithCommitParams
+    );
+    const labels = pulls.flatMap(p => p.labels.map(l => l.name));
+    const tagNames = latestReleaseVersion.split('.');
+    let version;
+
+    if (labels.includes('major release')) {
+        version = [`v${Number(tagNames[0].replace('v', '')) + 1}`, 0, 0];
+    } else if (labels.includes('minor release')) {
+        version = [tagNames[0], Number(tagNames[1]) + 1, 0];
+    } else {
+        version = [tagNames[0], tagNames[1], Number(tagNames[2]) + 1];
+    }
+
+    return version.join('.');
+}


### PR DESCRIPTION
CI内のスクリプトを別ファイルに分離することで、super-linter等でコードの質を高めやすくします。