### PR TITLE
tscを依存関係から削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "textlint-rule-preset-ja-spacing": "3.0.2",
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
         "textlint-rule-terminology": "5.2.16",
-        "tsc": "2.0.4",
         "typescript": "7.0.2"
       },
       "engines": {
@@ -8492,17 +8491,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tsc": {
-      "version": "2.0.4",
-      "resolved": "https://npm.flatt.tech/tsc/-/tsc-2.0.4.tgz",
-      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsc": "bin/tsc"
       }
     },
     "node_modules/tunnel": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "textlint-rule-preset-ja-spacing": "3.0.2",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "textlint-rule-terminology": "5.2.16",
-    "tsc": "2.0.4",
     "typescript": "7.0.2"
   },
   "engines": {


### PR DESCRIPTION
tscをpackage.jsonに記載する依存関係としてインストールすることは非推奨になっているので削除します。